### PR TITLE
feat: 게시글 생성, 단건 조회, 페이징 조회, 수정, 삭제 기능 추가

### DIFF
--- a/src/main/java/com/study/everytime/domain/post/controller/PostController.java
+++ b/src/main/java/com/study/everytime/domain/post/controller/PostController.java
@@ -1,0 +1,45 @@
+package com.study.everytime.domain.post.controller;
+
+import com.study.everytime.domain.post.dto.CreatePostDto;
+import com.study.everytime.domain.post.dto.ReadPostDto;
+import com.study.everytime.domain.post.dto.UpdatePostDto;
+import com.study.everytime.domain.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/board/{boardId}/post")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public void createPost(@AuthenticationPrincipal Long userId, @PathVariable Long boardId, @RequestBody CreatePostDto dto) {
+        postService.createPost(userId, boardId, dto);
+    }
+
+    @GetMapping("/{postId}")
+    public ReadPostDto readPost(@PathVariable Long postId) {
+        return postService.readPost(postId);
+    }
+
+    @GetMapping
+    public Slice<ReadPostDto> readPostPage(@PathVariable Long boardId, Pageable pageable) {
+        return postService.readPostPage(boardId, pageable);
+    }
+
+    @PatchMapping("/{postId}")
+    public void updatePost(@AuthenticationPrincipal Long userId, @PathVariable Long postId, @RequestBody UpdatePostDto dto) {
+        postService.updatePost(userId, postId, dto);
+    }
+
+    @DeleteMapping("/{postId}")
+    public void deletePost(@AuthenticationPrincipal Long userId, @PathVariable Long postId) {
+        postService.deletePost(userId, postId);
+    }
+
+}

--- a/src/main/java/com/study/everytime/domain/post/dto/CreatePostDto.java
+++ b/src/main/java/com/study/everytime/domain/post/dto/CreatePostDto.java
@@ -1,0 +1,7 @@
+package com.study.everytime.domain.post.dto;
+
+public record CreatePostDto(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/study/everytime/domain/post/dto/ReadPostDto.java
+++ b/src/main/java/com/study/everytime/domain/post/dto/ReadPostDto.java
@@ -1,0 +1,15 @@
+package com.study.everytime.domain.post.dto;
+
+import java.time.LocalDateTime;
+
+public record ReadPostDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        String username,
+        Long likes,
+        Long scraps
+) {
+
+}

--- a/src/main/java/com/study/everytime/domain/post/dto/UpdatePostDto.java
+++ b/src/main/java/com/study/everytime/domain/post/dto/UpdatePostDto.java
@@ -1,0 +1,7 @@
+package com.study.everytime.domain.post.dto;
+
+public record UpdatePostDto(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/study/everytime/domain/post/entity/Like.java
+++ b/src/main/java/com/study/everytime/domain/post/entity/Like.java
@@ -1,0 +1,32 @@
+package com.study.everytime.domain.post.entity;
+
+import com.study.everytime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    public Like(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+
+}

--- a/src/main/java/com/study/everytime/domain/post/entity/Post.java
+++ b/src/main/java/com/study/everytime/domain/post/entity/Post.java
@@ -1,0 +1,51 @@
+package com.study.everytime.domain.post.entity;
+
+import com.study.everytime.domain.auditing.BaseEntity;
+import com.study.everytime.domain.board.entity.Board;
+import com.study.everytime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE post_id=?")
+@SQLRestriction("deleted_at is NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    private String title;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private User writer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    private LocalDateTime deletedAt;
+
+    public Post(String title, String content, User writer, Board board) {
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+        this.board = board;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/study/everytime/domain/post/entity/Scrap.java
+++ b/src/main/java/com/study/everytime/domain/post/entity/Scrap.java
@@ -1,0 +1,31 @@
+package com.study.everytime.domain.post.entity;
+
+import com.study.everytime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Scrap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "scrap_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    public Scrap(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+
+}

--- a/src/main/java/com/study/everytime/domain/post/exception/PostException.java
+++ b/src/main/java/com/study/everytime/domain/post/exception/PostException.java
@@ -1,0 +1,34 @@
+package com.study.everytime.domain.post.exception;
+
+import com.study.everytime.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class PostException extends BusinessException {
+
+    private static final String DEFAULT_CODE_PREFIX = "POST";
+
+    public PostException(String codePrefix, int errorCode, HttpStatus httpStatus, String errorMessage) {
+        super(codePrefix, errorCode, httpStatus, errorMessage);
+    }
+
+    public static final class PostNotFoundException extends PostException {
+        public PostNotFoundException() {
+            super(DEFAULT_CODE_PREFIX, 1, HttpStatus.BAD_REQUEST, "게시글을 찾을 수 없습니다.");
+        }
+
+        public PostNotFoundException(String message) {
+            super(DEFAULT_CODE_PREFIX, 1, HttpStatus.BAD_REQUEST, message);
+        }
+    }
+
+    public static final class PostAuthException extends PostException {
+        public PostAuthException() {
+            super(DEFAULT_CODE_PREFIX, 2, HttpStatus.BAD_REQUEST, "권한이 없습니다.");
+        }
+
+        public PostAuthException(String message) {
+            super(DEFAULT_CODE_PREFIX, 2, HttpStatus.BAD_REQUEST, message);
+        }
+    }
+
+}

--- a/src/main/java/com/study/everytime/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/study/everytime/domain/post/repository/PostRepository.java
@@ -1,0 +1,32 @@
+package com.study.everytime.domain.post.repository;
+
+import com.study.everytime.domain.post.dto.ReadPostDto;
+import com.study.everytime.domain.post.entity.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    @Query("""
+            select new com.study.everytime.domain.post.dto.ReadPostDto(p.id, p.title, p.content, p.createdAt, p.writer.username, count(l), count(s))
+            from Post p
+            left join Like l on l.post = p
+            left join Scrap s on s.post = p
+            where p.id = :postId
+            group by p.id
+            """)
+    Optional<ReadPostDto> findReadPostDtoById(Long postId);
+
+    @Query("""
+            select new com.study.everytime.domain.post.dto.ReadPostDto(p.id, p.title, p.content, p.createdAt, p.writer.username, count(l), count(s))
+            from Post p
+            left join Like l on l.post = p
+            left join Scrap s on s.post = p
+            where p.board.id = :boardId
+            group by p.id
+            """)
+    Slice<ReadPostDto> findByBoard_Id(Long boardId, Pageable pageable);
+}

--- a/src/main/java/com/study/everytime/domain/post/service/PostService.java
+++ b/src/main/java/com/study/everytime/domain/post/service/PostService.java
@@ -1,0 +1,88 @@
+package com.study.everytime.domain.post.service;
+
+import com.study.everytime.domain.board.entity.Board;
+import com.study.everytime.domain.board.exception.BoardException;
+import com.study.everytime.domain.board.repository.BoardRepository;
+import com.study.everytime.domain.post.dto.CreatePostDto;
+import com.study.everytime.domain.post.dto.ReadPostDto;
+import com.study.everytime.domain.post.dto.UpdatePostDto;
+import com.study.everytime.domain.post.entity.Post;
+import com.study.everytime.domain.post.exception.PostException;
+import com.study.everytime.domain.post.repository.PostRepository;
+import com.study.everytime.domain.user.entity.User;
+import com.study.everytime.domain.user.exception.UserException;
+import com.study.everytime.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    public void createPost(Long userId, Long boardId, CreatePostDto dto) {
+        User user = getUser(userId);
+        Board board = getBoard(boardId);
+
+        log.info("title: {}, content: {}", dto.title(), dto.content());
+
+        Post post = new Post(dto.title(), dto.content(), user, board);
+        postRepository.save(post);
+    }
+
+    @Transactional(readOnly = true)
+    public ReadPostDto readPost(Long postId) {
+        return postRepository.findReadPostDtoById(postId)
+                .orElseThrow(PostException.PostNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ReadPostDto> readPostPage(Long boardId, Pageable pageable) {
+        return postRepository.findByBoard_Id(boardId, pageable);
+    }
+
+    public void updatePost(Long userId, Long postId, UpdatePostDto dto) {
+        Post post = getPost(postId);
+
+        if (!post.getWriter().getId().equals(userId)) {
+            throw new PostException.PostAuthException();
+        }
+
+        post.update(dto.title(), dto.content());
+    }
+
+    public void deletePost(Long userId, Long postId) {
+        Post post = getPost(postId);
+
+        if (!post.getWriter().getId().equals(userId)) {
+            throw new PostException.PostAuthException();
+        }
+
+        postRepository.delete(post);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserException.UserNotFoundException::new);
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(PostException.PostNotFoundException::new);
+    }
+
+    private Board getBoard(Long boardId) {
+        return boardRepository.findById(boardId)
+                .orElseThrow(BoardException.BoardNotFoundException::new);
+    }
+
+}


### PR DESCRIPTION
Issue: #11 
- Post, Like, Scrap 엔티티 생성
- 생성, 단건 조회, 페이징 조회, 수정, 삭제 기능 추가
- PostException 예외 추가
- JPA DTO 기반 프로젝션으로 ReadPostDto로 바로 조회