### PR TITLE
refactor: DTO 형식 변경

### DIFF
--- a/src/main/java/com/study/everytime/domain/post/controller/PostController.java
+++ b/src/main/java/com/study/everytime/domain/post/controller/PostController.java
@@ -1,8 +1,6 @@
 package com.study.everytime.domain.post.controller;
 
-import com.study.everytime.domain.post.dto.CreatePostDto;
-import com.study.everytime.domain.post.dto.ReadPostDto;
-import com.study.everytime.domain.post.dto.UpdatePostDto;
+import com.study.everytime.domain.post.dto.*;
 import com.study.everytime.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,8 +20,8 @@ public class PostController {
     }
 
     @GetMapping("/board/{boardId}/post")
-    public Slice<ReadPostDto> readBoardPosts(@AuthenticationPrincipal Long userId, @PathVariable Long boardId, Pageable pageable) {
-        return postService.readBoardPosts(userId, boardId, pageable);
+    public Slice<BoardPostPageDto> readBoardPosts(@PathVariable Long boardId, Pageable pageable) {
+        return postService.readBoardPosts(boardId, pageable);
     }
 
     @GetMapping("/post/{postId}")
@@ -57,7 +55,7 @@ public class PostController {
     }
 
     @GetMapping("/post/mypost")
-    public Slice<ReadPostDto> readMyPosts(@AuthenticationPrincipal Long userId, Pageable pageable) {
+    public Slice<MyPostPageDto> readMyPosts(@AuthenticationPrincipal Long userId, Pageable pageable) {
         return postService.readMyPosts(userId, pageable);
     }
 

--- a/src/main/java/com/study/everytime/domain/post/dto/BoardPostPageDto.java
+++ b/src/main/java/com/study/everytime/domain/post/dto/BoardPostPageDto.java
@@ -1,0 +1,14 @@
+package com.study.everytime.domain.post.dto;
+
+import java.time.LocalDateTime;
+
+public record BoardPostPageDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        String username,
+        Long likeCount
+) {
+
+}

--- a/src/main/java/com/study/everytime/domain/post/dto/MyPostPageDto.java
+++ b/src/main/java/com/study/everytime/domain/post/dto/MyPostPageDto.java
@@ -2,16 +2,14 @@ package com.study.everytime.domain.post.dto;
 
 import java.time.LocalDateTime;
 
-public record PostInformDto(
+public record MyPostPageDto(
         Long id,
+        String boardName,
         String title,
         String content,
         LocalDateTime createdAt,
-        Long writerId,
         String username,
-        Long likes,
-        Long scraps,
-        Boolean question,
-        Boolean anonymous
+        Long likeCount
 ) {
+
 }

--- a/src/main/java/com/study/everytime/domain/post/dto/ReadPostDto.java
+++ b/src/main/java/com/study/everytime/domain/post/dto/ReadPostDto.java
@@ -1,37 +1,41 @@
 package com.study.everytime.domain.post.dto;
 
+import com.study.everytime.domain.post.entity.Like;
+import com.study.everytime.domain.post.entity.Post;
+import com.study.everytime.domain.post.entity.Scrap;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record ReadPostDto(
         Long id,
+        String boardName,
         String title,
         String content,
         LocalDateTime createdAt,
         String username,
-        Long likes,
-        Long scraps,
-        Boolean question,
-        Boolean writer
+        int likeCount,
+        int scrapCount,
+        boolean isQuestion,
+        boolean isWriter,
+        boolean isLiked,
+        boolean isScraped
 ) {
 
-    public static ReadPostDto of(Long userId, PostInformDto dto) {
-        String displayName = dto.username();
-        if (dto.anonymous()) {
-            displayName = "익명";
-        }
-
-        Boolean writer = dto.writerId().equals(userId);
-
+    public static ReadPostDto of(Long userId, Post post, List<Like> likes, List<Scrap> scraps) {
         return new ReadPostDto(
-                dto.id(),
-                dto.title(),
-                dto.content(),
-                dto.createdAt(),
-                displayName,
-                dto.likes(),
-                dto.scraps(),
-                dto.question(),
-                writer
+                post.getId(),
+                post.getBoard().getName(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCreatedAt(),
+                post.getAnonymous() ? "익명" : post.getWriter().getUsername(),
+                likes.size(),
+                scraps.size(),
+                post.getQuestion(),
+                post.getWriter().getId().equals(userId),
+                likes.stream().anyMatch(l -> l.getUser().getId().equals(userId)),
+                scraps.stream().anyMatch(s -> s.getUser().getId().equals(userId))
         );
     }
 

--- a/src/main/java/com/study/everytime/domain/post/exception/PostException.java
+++ b/src/main/java/com/study/everytime/domain/post/exception/PostException.java
@@ -31,22 +31,22 @@ public class PostException extends BusinessException {
         }
     }
 
-    public static final class PostQuestionDeleteException extends PostException {
-        public PostQuestionDeleteException() {
+    public static final class QuestionNotDeletableException extends PostException {
+        public QuestionNotDeletableException() {
             super(DEFAULT_CODE_PREFIX, 3, HttpStatus.BAD_REQUEST, "질문글은 삭제할 수 없습니다.");
         }
 
-        public PostQuestionDeleteException(String message) {
+        public QuestionNotDeletableException(String message) {
             super(DEFAULT_CODE_PREFIX, 3, HttpStatus.BAD_REQUEST, message);
         }
     }
 
-    public static final class LikeDuplicateException extends PostException {
-        public LikeDuplicateException() {
+    public static final class LikeDuplicatedException extends PostException {
+        public LikeDuplicatedException() {
             super(DEFAULT_CODE_PREFIX, 4, HttpStatus.BAD_REQUEST, "이미 공감한 글입니다.");
         }
 
-        public LikeDuplicateException(String message) {
+        public LikeDuplicatedException(String message) {
             super(DEFAULT_CODE_PREFIX, 4, HttpStatus.BAD_REQUEST, message);
         }
     }

--- a/src/main/java/com/study/everytime/domain/post/repository/LikeRepository.java
+++ b/src/main/java/com/study/everytime/domain/post/repository/LikeRepository.java
@@ -3,6 +3,9 @@ package com.study.everytime.domain.post.repository;
 import com.study.everytime.domain.post.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUser_IdAndPost_Id(Long userId, Long postId);
+    List<Like> findByPost_Id(Long postId);
 }

--- a/src/main/java/com/study/everytime/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/study/everytime/domain/post/repository/PostRepository.java
@@ -1,45 +1,32 @@
 package com.study.everytime.domain.post.repository;
 
-import com.study.everytime.domain.post.dto.PostInformDto;
+import com.study.everytime.domain.post.dto.BoardPostPageDto;
+import com.study.everytime.domain.post.dto.MyPostPageDto;
 import com.study.everytime.domain.post.entity.Post;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
-
 public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("""
-            select new com.study.everytime.domain.post.dto.PostInformDto(
-                p.id, p.title, p.content, p.createdAt, p.writer.id, p.writer.username, count(l), count(s), p.question, p.anonymous)
+            select new com.study.everytime.domain.post.dto.BoardPostPageDto(
+                p.id, p.title, p.content, p.createdAt, p.writer.username, count(l))
             from Post p
             left join Like l on l.post = p
-            left join Scrap s on s.post = p
-            where p.id = :postId
-            group by p.id
-            """)
-    Optional<PostInformDto> findReadPostDtoById(Long postId);
-
-    @Query("""
-            select new com.study.everytime.domain.post.dto.PostInformDto(
-                p.id, p.title, p.content, p.createdAt, p.writer.id, p.writer.username, count(l), count(s), p.question, p.anonymous)
-            from Post p
-            left join Like l on l.post = p
-            left join Scrap s on s.post = p
             where p.board.id = :boardId
             group by p.id
             """)
-    Slice<PostInformDto> findByBoard_Id(Long boardId, Pageable pageable);
+    Slice<BoardPostPageDto> findByBoard_Id(Long boardId, Pageable pageable);
 
     @Query("""
-            select new com.study.everytime.domain.post.dto.PostInformDto(
-                p.id, p.title, p.content, p.createdAt, p.writer.id, p.writer.username, count(l), count(s), p.question, p.anonymous)
+            select new com.study.everytime.domain.post.dto.MyPostPageDto(
+                p.id, b.name, p.title, p.content, p.createdAt, p.writer.username, count(l))
             from Post p
+            join Board b on b = p.board
             left join Like l on l.post = p
-            left join Scrap s on s.post = p
             where p.writer.id = :userId
             group by p.id
             """)
-    Slice<PostInformDto> findByWriter_id(Long userId, Pageable pageable);
+    Slice<MyPostPageDto> findByWriter_id(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/study/everytime/domain/post/repository/ScrapRepository.java
+++ b/src/main/java/com/study/everytime/domain/post/repository/ScrapRepository.java
@@ -3,9 +3,11 @@ package com.study.everytime.domain.post.repository;
 import com.study.everytime.domain.post.entity.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     boolean existsByUser_IdAndPost_Id(Long userId, Long postId);
     Optional<Scrap> findByUser_IdAndPost_Id(Long userId, Long postId);
+    List<Scrap> findByPost_Id(Long postId);
 }

--- a/src/main/java/com/study/everytime/domain/post/service/PostService.java
+++ b/src/main/java/com/study/everytime/domain/post/service/PostService.java
@@ -3,10 +3,7 @@ package com.study.everytime.domain.post.service;
 import com.study.everytime.domain.board.entity.Board;
 import com.study.everytime.domain.board.exception.BoardException;
 import com.study.everytime.domain.board.repository.BoardRepository;
-import com.study.everytime.domain.post.dto.CreatePostDto;
-import com.study.everytime.domain.post.dto.PostInformDto;
-import com.study.everytime.domain.post.dto.ReadPostDto;
-import com.study.everytime.domain.post.dto.UpdatePostDto;
+import com.study.everytime.domain.post.dto.*;
 import com.study.everytime.domain.post.entity.Like;
 import com.study.everytime.domain.post.entity.Post;
 import com.study.everytime.domain.post.entity.Scrap;
@@ -24,6 +21,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -40,7 +39,7 @@ public class PostService {
         User user = getUser(userId);
         Board board = getBoard(boardId);
 
-        log.info("title: {}, content: {}, question: {}, anonymous: {}", dto.title(), dto.content(), dto.question(), dto.anonymous());
+        log.info("title: {}, content: {}, isQuestion: {}, anonymous: {}", dto.title(), dto.content(), dto.question(), dto.anonymous());
 
         Post post = new Post(dto.title(), dto.content(), dto.question(), dto.anonymous(), user, board);
         postRepository.save(post);
@@ -48,15 +47,15 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public ReadPostDto readPost(Long userId, Long postId) {
-        PostInformDto postInformDto = postRepository.findReadPostDtoById(postId)
-                .orElseThrow(PostException.PostNotFoundException::new);
-        return ReadPostDto.of(userId, postInformDto);
+        Post post = getPost(postId);
+        List<Like> likes = likeRepository.findByPost_Id(postId);
+        List<Scrap> scraps = scrapRepository.findByPost_Id(postId);
+        return ReadPostDto.of(userId, post, likes, scraps);
     }
 
     @Transactional(readOnly = true)
-    public Slice<ReadPostDto> readBoardPosts(Long userId, Long boardId, Pageable pageable) {
-        return postRepository.findByBoard_Id(boardId, pageable)
-                .map(inform -> ReadPostDto.of(userId, inform));
+    public Slice<BoardPostPageDto> readBoardPosts(Long boardId, Pageable pageable) {
+        return postRepository.findByBoard_Id(boardId, pageable);
     }
 
     public void updatePost(Long userId, Long postId, UpdatePostDto dto) {
@@ -114,9 +113,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<ReadPostDto> readMyPosts(Long userId, Pageable pageable) {
-        return postRepository.findByWriter_id(userId, pageable)
-                .map(inform -> ReadPostDto.of(userId, inform));
+    public Slice<MyPostPageDto> readMyPosts(Long userId, Pageable pageable) {
+        return postRepository.findByWriter_id(userId, pageable);
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/study/everytime/domain/post/service/PostService.java
+++ b/src/main/java/com/study/everytime/domain/post/service/PostService.java
@@ -77,7 +77,7 @@ public class PostService {
         }
 
         if (post.getQuestion()) {
-            throw new PostException.PostQuestionDeleteException();
+            throw new PostException.QuestionNotDeletableException();
         }
 
         postRepository.delete(post);
@@ -85,7 +85,7 @@ public class PostService {
 
     public void addLike(Long userId, Long postId) {
         if (likeRepository.existsByUser_IdAndPost_Id(userId, postId)) {
-            throw new PostException.LikeDuplicateException();
+            throw new PostException.LikeDuplicatedException();
         }
 
         User user = getUser(userId);


### PR DESCRIPTION
Issue: #11 
- DB 조회 DTO PostInformDto -> BoardPostPageDto, MyPostPageDto로 분리
- 게시글 단건 조회 시 Post, Like, Scrap 쿼리 분리
- DTO 필드명 변경
- ReadPostDto에 isLiked, isScraped 필드 추가
- ReadPostDto, MyPostDto에 boardName 필드 추가
- 예외명 변경